### PR TITLE
ABI and bytecode save to filesystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ The result of the call will be displayed in the text area next to the action but
 
 <p align="center"><img src=".github/actions.png" alt="Contracts panel"></p>
 
+**You can find the ABI and bytecode (JSON format) in the `build` folder**, which is generated when you compile.
+
 ## For contributors
 
 If you want to contribute to this project, fork, install the dependencies and run the development tools. On windows, you may need to install the [build tools](https://github.com/felixrieseberg/windows-build-tools) using: `npm install --global windows-build-tools`  

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "solidity-ide",
-  "version": "2.2.4",
+  "version": "2.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4119,6 +4119,15 @@
         "file-uri-to-path": "1.0.0"
       }
     },
+    "bip66": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
+      "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "bl": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
@@ -4392,16 +4401,6 @@
       "requires": {
         "bn.js": "^4.1.0",
         "randombytes": "^2.0.1"
-      }
-    },
-    "browserify-sha3": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/browserify-sha3/-/browserify-sha3-0.0.4.tgz",
-      "integrity": "sha1-CGxHuMgjFsnUcCLCYYWVRXbdjiY=",
-      "dev": true,
-      "requires": {
-        "js-sha3": "^0.6.1",
-        "safe-buffer": "^5.1.1"
       }
     },
     "browserify-sign": {
@@ -6369,6 +6368,17 @@
         "rimraf": "^2.6.1"
       }
     },
+    "drbg.js": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
+      "integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
+      "dev": true,
+      "requires": {
+        "browserify-aes": "^1.0.6",
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4"
+      }
+    },
     "duplexer": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
@@ -6909,48 +6919,54 @@
       "requires": {
         "idna-uts46-hx": "^2.3.1",
         "js-sha3": "^0.5.7"
-      },
-      "dependencies": {
-        "js-sha3": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
-          "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=",
-          "dev": true
-        }
       }
     },
     "eth-lib": {
-      "version": "0.1.27",
-      "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.1.27.tgz",
-      "integrity": "sha512-B8czsfkJYzn2UIEMwjc7Mbj+Cy72V+/OXH/tb44LV8jhrjizQJJ325xMOMyk3+ETa6r6oi0jsUY14+om8mQMWA==",
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+      "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
       "dev": true,
       "requires": {
         "bn.js": "^4.11.6",
         "elliptic": "^6.4.0",
-        "keccakjs": "^0.2.1",
-        "nano-json-stream-parser": "^0.1.2",
-        "servify": "^0.1.12",
-        "ws": "^3.0.0",
         "xhr-request-promise": "^0.1.2"
-      },
-      "dependencies": {
-        "ws": {
-          "version": "3.3.3",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
-          "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
-          "dev": true,
-          "requires": {
-            "async-limiter": "~1.0.0",
-            "safe-buffer": "~5.1.0",
-            "ultron": "~1.1.0"
-          }
-        }
+      }
+    },
+    "ethereum-common": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.18.tgz",
+      "integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8=",
+      "dev": true
+    },
+    "ethereumjs-tx": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-1.3.7.tgz",
+      "integrity": "sha512-wvLMxzt1RPhAQ9Yi3/HKZTn0FZYpnsmQdbKYfUUpi4j1SEIcbkd9tndVjcPrufY3V7j2IebOpC00Zp2P/Ay2kA==",
+      "dev": true,
+      "requires": {
+        "ethereum-common": "^0.0.18",
+        "ethereumjs-util": "^5.0.0"
+      }
+    },
+    "ethereumjs-util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+      "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+      "dev": true,
+      "requires": {
+        "bn.js": "^4.11.0",
+        "create-hash": "^1.1.2",
+        "ethjs-util": "^0.1.3",
+        "keccak": "^1.0.2",
+        "rlp": "^2.0.0",
+        "safe-buffer": "^5.1.1",
+        "secp256k1": "^3.0.1"
       }
     },
     "ethers": {
-      "version": "4.0.27",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.27.tgz",
-      "integrity": "sha512-+DXZLP/tyFnXWxqr2fXLT67KlGUfLuvDkHSOtSC9TUVG9OIj6yrG5JPeXRMYo15xkOYwnjgdMKrXp5V94rtjJA==",
+      "version": "4.0.28",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.28.tgz",
+      "integrity": "sha512-5JTHrPoFLqf+xCAI3pKwXSOgWBSJJoAUdPtPLr1ZlKbSKiIFMkPlRNovmZS3jhIw5sHW1YoVWOaJ6ZR2gKRbwg==",
       "dev": true,
       "requires": {
         "@types/node": "^10.3.2",
@@ -6966,9 +6982,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.14.6",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.6.tgz",
-          "integrity": "sha512-Fvm24+u85lGmV4hT5G++aht2C5I4Z4dYlWZIh62FAfFO/TfzXtPpoLI6I7AuBWkIFqZCnhFOoTT7RjjaIL5Fjg==",
+          "version": "10.14.8",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.8.tgz",
+          "integrity": "sha512-I4+DbJEhLEg4/vIy/2gkWDvXBOOtPKV9EnLhYjMoqxcRW+TTZtUftkHktz/a8suoD5mUL7m6ReLrkPvSsCQQmw==",
           "dev": true
         },
         "elliptic": {
@@ -6992,12 +7008,6 @@
             "inherits": "^2.0.3",
             "minimalistic-assert": "^1.0.0"
           }
-        },
-        "js-sha3": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
-          "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=",
-          "dev": true
         },
         "setimmediate": {
           "version": "1.0.4",
@@ -7029,6 +7039,16 @@
           "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
           "dev": true
         }
+      }
+    },
+    "ethjs-util": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.6.tgz",
+      "integrity": "sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==",
+      "dev": true,
+      "requires": {
+        "is-hex-prefixed": "1.0.0",
+        "strip-hex-prefix": "1.0.0"
       }
     },
     "event-pubsub": {
@@ -7755,15 +7775,6 @@
         "universalify": "^0.1.0"
       }
     },
-    "fs-minipass": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
-      "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
-      "dev": true,
-      "requires": {
-        "minipass": "^2.2.1"
-      }
-    },
     "fs-write-stream-atomic": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
@@ -8330,9 +8341,9 @@
       }
     },
     "fstream": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -9459,12 +9470,6 @@
         "statuses": ">= 1.4.0 < 2"
       }
     },
-    "http-https": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/http-https/-/http-https-1.0.0.tgz",
-      "integrity": "sha1-L5CN1fHbQGjAWM1ubUzjkskTOJs=",
-      "dev": true
-    },
     "http-parser-js": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.0.tgz",
@@ -10283,9 +10288,9 @@
       }
     },
     "js-sha3": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.6.1.tgz",
-      "integrity": "sha1-W4n3enR3Z5h39YxKB1JAk0sflcA=",
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
+      "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=",
       "dev": true
     },
     "js-tokens": {
@@ -10397,16 +10402,6 @@
         "inherits": "^2.0.3",
         "nan": "^2.2.1",
         "safe-buffer": "^5.1.0"
-      }
-    },
-    "keccakjs": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/keccakjs/-/keccakjs-0.2.3.tgz",
-      "integrity": "sha512-BjLkNDcfaZ6l8HBG9tH0tpmDv3sS2mA7FNQxFHpCdzP3Gb2MVruXBSuoM66SnVxKJpAr5dKGdkHD+bDokt8fTg==",
-      "dev": true,
-      "requires": {
-        "browserify-sha3": "^0.0.4",
-        "sha3": "^1.2.2"
       }
     },
     "killable": {
@@ -11036,25 +11031,6 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
-    "minipass": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
-      "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "^5.1.2",
-        "yallist": "^3.0.0"
-      }
-    },
-    "minizlib": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
-      "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
-      "dev": true,
-      "requires": {
-        "minipass": "^2.2.1"
-      }
-    },
     "mississippi": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
@@ -11129,21 +11105,6 @@
         }
       }
     },
-    "mkdirp-promise": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/mkdirp-promise/-/mkdirp-promise-5.0.1.tgz",
-      "integrity": "sha1-6bj2jlUsaKnBcTuEiD96HdA5uKE=",
-      "dev": true,
-      "requires": {
-        "mkdirp": "*"
-      }
-    },
-    "mock-fs": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.9.0.tgz",
-      "integrity": "sha512-aUj0qIniTNxzGqAC61Bvro7YD37tIBnMw3wpClucUVgNBS7r6YQn/M4wuoH7SGteKz4SvC1OBeDsfpG0MYC+1Q==",
-      "dev": true
-    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -11201,12 +11162,6 @@
       "version": "2.12.1",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
       "integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw=="
-    },
-    "nano-json-stream-parser": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/nano-json-stream-parser/-/nano-json-stream-parser-0.1.2.tgz",
-      "integrity": "sha1-DMj20OK2IrR5xA1JnEbWS3Vcb18=",
-      "dev": true
     },
     "nanoid": {
       "version": "2.0.1",
@@ -11800,15 +11755,6 @@
         "has": "^1.0.3"
       }
     },
-    "oboe": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/oboe/-/oboe-2.1.4.tgz",
-      "integrity": "sha1-IMiM2wwVNxuwQRklfU/dNLCqSfY=",
-      "dev": true,
-      "requires": {
-        "http-https": "^1.0.0"
-      }
-    },
     "obuf": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
@@ -11962,12 +11908,6 @@
         "os-tmpdir": "^1.0.0"
       }
     },
-    "p-cancelable": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
-      "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw==",
-      "dev": true
-    },
     "p-defer": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
@@ -12008,15 +11948,6 @@
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
       "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
       "dev": true
-    },
-    "p-timeout": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
-      "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
-      "dev": true,
-      "requires": {
-        "p-finally": "^1.0.0"
-      }
     },
     "p-try": {
       "version": "2.0.0",
@@ -13216,12 +13147,6 @@
         "safe-buffer": "^5.1.0"
       }
     },
-    "randomhex": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/randomhex/-/randomhex-0.1.5.tgz",
-      "integrity": "sha1-us7vmCMpCRQA8qKRLGzQLxCU9YU=",
-      "dev": true
-    },
     "range-parser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
@@ -13794,6 +13719,16 @@
         "inherits": "^2.0.1"
       }
     },
+    "rlp": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.3.tgz",
+      "integrity": "sha512-l6YVrI7+d2vpW6D6rS05x2Xrmq8oW7v3pieZOJKBEdjuTF4Kz/iwk55Zyh1Zaz+KOB2kC8+2jZlp2u9L4tTzCQ==",
+      "dev": true,
+      "requires": {
+        "bn.js": "^4.11.1",
+        "safe-buffer": "^5.1.1"
+      }
+    },
     "rss-parser": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/rss-parser/-/rss-parser-3.7.0.tgz",
@@ -14032,6 +13967,7 @@
       "resolved": "https://registry.npmjs.org/scrypt/-/scrypt-6.0.3.tgz",
       "integrity": "sha1-BOAUpWgrU/pQwtXM4WfXGcBthw0=",
       "dev": true,
+      "optional": true,
       "requires": {
         "nan": "^2.0.8"
       }
@@ -14043,9 +13979,9 @@
       "dev": true
     },
     "scrypt.js": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/scrypt.js/-/scrypt.js-0.2.0.tgz",
-      "integrity": "sha1-r40UZbcemZARC+38WTuUeeA6ito=",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/scrypt.js/-/scrypt.js-0.3.0.tgz",
+      "integrity": "sha512-42LTc1nyFsyv/o0gcHtDztrn+aqpkaCNt5Qh7ATBZfhEZU7IC/0oT/qbBH+uRNoAPvs2fwiOId68FDEoSRA8/A==",
       "dev": true,
       "requires": {
         "scrypt": "^6.0.2",
@@ -14087,6 +14023,30 @@
       "resolved": "https://registry.npmjs.org/sec/-/sec-1.0.0.tgz",
       "integrity": "sha1-Az1go60g7PLgCUDRT5eCNGV3QzU=",
       "dev": true
+    },
+    "secp256k1": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.7.1.tgz",
+      "integrity": "sha512-1cf8sbnRreXrQFdH6qsg2H71Xw91fCCS9Yp021GnUNJzWJS/py96fS4lHbnTnouLp08Xj6jBoBB6V78Tdbdu5g==",
+      "dev": true,
+      "requires": {
+        "bindings": "^1.5.0",
+        "bip66": "^1.1.5",
+        "bn.js": "^4.11.8",
+        "create-hash": "^1.2.0",
+        "drbg.js": "^1.0.1",
+        "elliptic": "^6.4.1",
+        "nan": "^2.14.0",
+        "safe-buffer": "^5.1.2"
+      },
+      "dependencies": {
+        "nan": {
+          "version": "2.14.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+          "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+          "dev": true
+        }
+      }
     },
     "seek-bzip": {
       "version": "1.0.5",
@@ -14233,19 +14193,6 @@
         "send": "0.16.2"
       }
     },
-    "servify": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/servify/-/servify-0.1.12.tgz",
-      "integrity": "sha512-/xE6GvsKKqyo1BAY+KxOWXcLpPsUUyji7Qg3bVD7hh1eRze5bR1uYiuDA/k3Gof1s9BTzQZEJK8sNcNGFIzeWw==",
-      "dev": true,
-      "requires": {
-        "body-parser": "^1.16.0",
-        "cors": "^2.8.1",
-        "express": "^4.14.0",
-        "request": "^2.79.0",
-        "xhr": "^2.3.3"
-      }
-    },
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
@@ -14293,23 +14240,6 @@
       "requires": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
-      }
-    },
-    "sha3": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/sha3/-/sha3-1.2.3.tgz",
-      "integrity": "sha512-sOWDZi8cDBRkLfWOw18wvJyNblXDHzwMGnRWut8zNNeIeLnmMRO17bjpLc7OzMuj1ASUgx2IyohzUCAl+Kx5vA==",
-      "dev": true,
-      "requires": {
-        "nan": "2.13.2"
-      },
-      "dependencies": {
-        "nan": {
-          "version": "2.13.2",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
-          "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
-          "dev": true
-        }
       }
     },
     "shallow-clone": {
@@ -15268,82 +15198,6 @@
         "util.promisify": "~1.0.0"
       }
     },
-    "swarm-js": {
-      "version": "0.1.39",
-      "resolved": "https://registry.npmjs.org/swarm-js/-/swarm-js-0.1.39.tgz",
-      "integrity": "sha512-QLMqL2rzF6n5s50BptyD6Oi0R1aWlJC5Y17SRIVXRj6OR1DRIPM7nepvrxxkjA1zNzFz6mUOMjfeqeDaWB7OOg==",
-      "dev": true,
-      "requires": {
-        "bluebird": "^3.5.0",
-        "buffer": "^5.0.5",
-        "decompress": "^4.0.0",
-        "eth-lib": "^0.1.26",
-        "fs-extra": "^4.0.2",
-        "got": "^7.1.0",
-        "mime-types": "^2.1.16",
-        "mkdirp-promise": "^5.0.1",
-        "mock-fs": "^4.1.0",
-        "setimmediate": "^1.0.5",
-        "tar": "^4.0.2",
-        "xhr-request-promise": "^0.1.2"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
-          "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        },
-        "get-stream": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-          "dev": true
-        },
-        "got": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
-          "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
-          "dev": true,
-          "requires": {
-            "decompress-response": "^3.2.0",
-            "duplexer3": "^0.1.4",
-            "get-stream": "^3.0.0",
-            "is-plain-obj": "^1.1.0",
-            "is-retry-allowed": "^1.0.0",
-            "is-stream": "^1.0.0",
-            "isurl": "^1.0.0-alpha5",
-            "lowercase-keys": "^1.0.0",
-            "p-cancelable": "^0.3.0",
-            "p-timeout": "^1.1.1",
-            "safe-buffer": "^5.0.1",
-            "timed-out": "^4.0.0",
-            "url-parse-lax": "^1.0.0",
-            "url-to-options": "^1.0.1"
-          }
-        },
-        "tar": {
-          "version": "4.4.8",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
-          "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
-          "dev": true,
-          "requires": {
-            "chownr": "^1.1.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.3.4",
-            "minizlib": "^1.1.1",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.2"
-          }
-        }
-      }
-    },
     "symbol-observable": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
@@ -15403,13 +15257,13 @@
       "dev": true
     },
     "tar": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
+      "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
       "dev": true,
       "requires": {
         "block-stream": "*",
-        "fstream": "^1.0.2",
+        "fstream": "^1.0.12",
         "inherits": "2"
       }
     },
@@ -15936,12 +15790,6 @@
           "dev": true
         }
       }
-    },
-    "ultron": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
-      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
-      "dev": true
     },
     "unbzip2-stream": {
       "version": "1.3.3",
@@ -16526,315 +16374,278 @@
       }
     },
     "web3": {
-      "version": "1.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/web3/-/web3-1.0.0-beta.46.tgz",
-      "integrity": "sha512-a+apA/pXiivrurVEq5Pv9+0GZ5vC6Utu8M9fojW9YUuvory29WFDg+tg+ITBmMvz/dQxInahNS32xJB6HhZbHg==",
+      "version": "1.0.0-beta.55",
+      "resolved": "https://registry.npmjs.org/web3/-/web3-1.0.0-beta.55.tgz",
+      "integrity": "sha512-yJpwy4IUA3T/F9hWzYQVn0GbJCrAaZ0KTIO3iuqkhaYH0Y09KV7k4GzFi4hN7hT4cFTj4yIKaeVCwQ5kzvi2Vg==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.3.1",
         "@types/node": "^10.12.18",
-        "web3-bzz": "1.0.0-beta.46",
-        "web3-core": "1.0.0-beta.46",
-        "web3-core-helpers": "1.0.0-beta.46",
-        "web3-core-method": "1.0.0-beta.46",
-        "web3-eth": "1.0.0-beta.46",
-        "web3-eth-personal": "1.0.0-beta.46",
-        "web3-net": "1.0.0-beta.46",
-        "web3-providers": "1.0.0-beta.46",
-        "web3-shh": "1.0.0-beta.46",
-        "web3-utils": "1.0.0-beta.46"
+        "web3-core": "1.0.0-beta.55",
+        "web3-eth": "1.0.0-beta.55",
+        "web3-eth-personal": "1.0.0-beta.55",
+        "web3-net": "1.0.0-beta.55",
+        "web3-providers": "1.0.0-beta.55",
+        "web3-shh": "1.0.0-beta.55",
+        "web3-utils": "1.0.0-beta.55"
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.14.6",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.6.tgz",
-          "integrity": "sha512-Fvm24+u85lGmV4hT5G++aht2C5I4Z4dYlWZIh62FAfFO/TfzXtPpoLI6I7AuBWkIFqZCnhFOoTT7RjjaIL5Fjg==",
-          "dev": true
-        }
-      }
-    },
-    "web3-bzz": {
-      "version": "1.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.0.0-beta.46.tgz",
-      "integrity": "sha512-l2gnK3wM+dfBfGIbxwz7ZE9mhDMArrENbLmFDMCrNng/PurrXy16GQJ5ziLCt4D2kyO4VWtnGeG2yGiEJSI+Vg==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.3.1",
-        "@types/node": "^10.12.18",
-        "lodash": "^4.17.11",
-        "swarm-js": "^0.1.39"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "10.14.6",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.6.tgz",
-          "integrity": "sha512-Fvm24+u85lGmV4hT5G++aht2C5I4Z4dYlWZIh62FAfFO/TfzXtPpoLI6I7AuBWkIFqZCnhFOoTT7RjjaIL5Fjg==",
+          "version": "10.14.8",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.8.tgz",
+          "integrity": "sha512-I4+DbJEhLEg4/vIy/2gkWDvXBOOtPKV9EnLhYjMoqxcRW+TTZtUftkHktz/a8suoD5mUL7m6ReLrkPvSsCQQmw==",
           "dev": true
         }
       }
     },
     "web3-core": {
-      "version": "1.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.0.0-beta.46.tgz",
-      "integrity": "sha512-9Iqp4Szn52ldo1dIJ3uzfKA73TkSvQKJd4lOwxMKK77qniP0C3qpRjTMZumIGsR3iydT0QWWgmxlaca0B4LRYQ==",
+      "version": "1.0.0-beta.55",
+      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.0.0-beta.55.tgz",
+      "integrity": "sha512-AMMp7TLEtE7u8IJAu/THrRhBTZyZzeo7Y6GiWYNwb5+KStC9hIGLr9cI1KX9R6ZioTOLRHrqT7awDhnJ1ku2mg==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.3.1",
+        "@types/bn.js": "^4.11.4",
         "@types/node": "^10.12.18",
         "lodash": "^4.17.11",
-        "web3-utils": "1.0.0-beta.46"
+        "web3-core-method": "1.0.0-beta.55",
+        "web3-providers": "1.0.0-beta.55",
+        "web3-utils": "1.0.0-beta.55"
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.14.6",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.6.tgz",
-          "integrity": "sha512-Fvm24+u85lGmV4hT5G++aht2C5I4Z4dYlWZIh62FAfFO/TfzXtPpoLI6I7AuBWkIFqZCnhFOoTT7RjjaIL5Fjg==",
+          "version": "10.14.8",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.8.tgz",
+          "integrity": "sha512-I4+DbJEhLEg4/vIy/2gkWDvXBOOtPKV9EnLhYjMoqxcRW+TTZtUftkHktz/a8suoD5mUL7m6ReLrkPvSsCQQmw==",
           "dev": true
         }
       }
     },
     "web3-core-helpers": {
-      "version": "1.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.0.0-beta.46.tgz",
-      "integrity": "sha512-bYUEVxW1LbhlLjwGHfyQ6otc41F91tPQVuarqWypaiFcYXJxQKxg8n5tEg89ZsiAxU23wlQvQMAJ2vg9r0g33A==",
+      "version": "1.0.0-beta.55",
+      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.0.0-beta.55.tgz",
+      "integrity": "sha512-suj9Xy/lIqajaYLJTEjr2rlFgu6hGYwChHmf8+qNrC2luZA6kirTamtB9VThWMxbywx7p0bqQFjW6zXogAgWhg==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.3.1",
         "lodash": "^4.17.11",
-        "web3-eth-iban": "1.0.0-beta.46",
-        "web3-utils": "1.0.0-beta.46"
+        "web3-core": "1.0.0-beta.55",
+        "web3-eth-iban": "1.0.0-beta.55",
+        "web3-utils": "1.0.0-beta.55"
       }
     },
     "web3-core-method": {
-      "version": "1.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.0.0-beta.46.tgz",
-      "integrity": "sha512-n++LCk2I6UEfbXJFsDPuw8mPn3T6iQLGMTaTBjhybmu1ok4o11xqxuN/Yv7dXWJVTlf2wDiiCIaLdHGQKdjilA==",
+      "version": "1.0.0-beta.55",
+      "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.0.0-beta.55.tgz",
+      "integrity": "sha512-w1cW/s2ji9qGELHk2uMJCn1ooay0JJLVoPD1nvmsW6OTRWcVjxa62nJrFQhe6P5lEb83Xk9oHgmCxZoVUHibOw==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.3.1",
         "eventemitter3": "3.1.0",
         "lodash": "^4.17.11",
-        "web3-core": "1.0.0-beta.46",
-        "web3-core-helpers": "1.0.0-beta.46",
-        "web3-core-promievent": "1.0.0-beta.46",
-        "web3-core-subscriptions": "1.0.0-beta.46",
-        "web3-utils": "1.0.0-beta.46"
-      }
-    },
-    "web3-core-promievent": {
-      "version": "1.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.0.0-beta.46.tgz",
-      "integrity": "sha512-Z0GuazAKpwEJKjE1BpFF74VQ8/hsGCU2vubF5AHrVHIZCaEKIw2mm7uccKyw6QELweOEDpxTM687Gnw2PU6QTw==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.3.1",
-        "eventemitter3": "^3.1.0"
+        "rxjs": "^6.4.0",
+        "web3-core": "1.0.0-beta.55",
+        "web3-core-helpers": "1.0.0-beta.55",
+        "web3-core-subscriptions": "1.0.0-beta.55",
+        "web3-utils": "1.0.0-beta.55"
       }
     },
     "web3-core-subscriptions": {
-      "version": "1.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.0.0-beta.46.tgz",
-      "integrity": "sha512-wgz6pMXS0hKdTiPXeWMbGMoDkxKwaHK9KZeSyRGHfzrTThins2PrbduC9yjl+M862zsb6DCk/oQ+AjnUoMnLow==",
+      "version": "1.0.0-beta.55",
+      "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.0.0-beta.55.tgz",
+      "integrity": "sha512-pb3oQbUzK7IoyXwag8TYInQddg0rr7BHxKc+Pbs/92hVNQ5ps4iGMVJKezdrjlQ1IJEEUiDIglXl4LZ1hIuMkw==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.3.1",
         "eventemitter3": "^3.1.0",
-        "lodash": "^4.17.11",
-        "web3-core-helpers": "1.0.0-beta.46",
-        "web3-utils": "1.0.0-beta.46"
+        "lodash": "^4.17.11"
       }
     },
     "web3-eth": {
-      "version": "1.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.0.0-beta.46.tgz",
-      "integrity": "sha512-9gUO3SPBAzL4t31iRmNi/7hK8+35YC3lJz6XH0t1dYhybF8rg5zqxMTjsxQFxcilS9N+4hoCVuA6fVpjAKn4Zg==",
+      "version": "1.0.0-beta.55",
+      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.0.0-beta.55.tgz",
+      "integrity": "sha512-F3zJ9I1gOgQdNGfi2Dy2lmj6OqCMJoRN01XHhQZagq0HY1JYMfObtfMi5E3L+qsegsSddHbqp4YY57tKx6uxpA==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "web3-core": "1.0.0-beta.46",
-        "web3-core-helpers": "1.0.0-beta.46",
-        "web3-core-method": "1.0.0-beta.46",
-        "web3-core-promievent": "1.0.0-beta.46",
-        "web3-core-subscriptions": "1.0.0-beta.46",
-        "web3-eth-abi": "1.0.0-beta.46",
-        "web3-eth-accounts": "1.0.0-beta.46",
-        "web3-eth-contract": "1.0.0-beta.46",
-        "web3-eth-ens": "1.0.0-beta.46",
-        "web3-eth-iban": "1.0.0-beta.46",
-        "web3-eth-personal": "1.0.0-beta.46",
-        "web3-net": "1.0.0-beta.46",
-        "web3-providers": "1.0.0-beta.46",
-        "web3-utils": "1.0.0-beta.46"
+        "ethereumjs-tx": "^1.3.7",
+        "rxjs": "^6.4.0",
+        "web3-core": "1.0.0-beta.55",
+        "web3-core-helpers": "1.0.0-beta.55",
+        "web3-core-method": "1.0.0-beta.55",
+        "web3-core-subscriptions": "1.0.0-beta.55",
+        "web3-eth-abi": "1.0.0-beta.55",
+        "web3-eth-accounts": "1.0.0-beta.55",
+        "web3-eth-contract": "1.0.0-beta.55",
+        "web3-eth-ens": "1.0.0-beta.55",
+        "web3-eth-iban": "1.0.0-beta.55",
+        "web3-eth-personal": "1.0.0-beta.55",
+        "web3-net": "1.0.0-beta.55",
+        "web3-providers": "1.0.0-beta.55",
+        "web3-utils": "1.0.0-beta.55"
       }
     },
     "web3-eth-abi": {
-      "version": "1.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.46.tgz",
-      "integrity": "sha512-Ac0JTptqZPpoiF+5sg6gJlNkFZPO77qRd39YxIKoxXaXLP8JPFujpNQUJBMJU6kxT9fMYmR1T453JQj3aMEHeQ==",
+      "version": "1.0.0-beta.55",
+      "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.55.tgz",
+      "integrity": "sha512-3h1xnm/vYmKUXTOYAOP0OsB5uijQV76pNNRGKOB6Dq6GR1pbcbD3WrB/4I643YA8l91t5FRzFzUiA3S77R2iqw==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "ethers": "^4.0.0",
+        "ethers": "^4.0.27",
         "lodash": "^4.17.11",
-        "web3-utils": "1.0.0-beta.46"
+        "web3-utils": "1.0.0-beta.55"
       }
     },
     "web3-eth-accounts": {
-      "version": "1.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.0.0-beta.46.tgz",
-      "integrity": "sha512-b5XYe3lcm1JZTqkO0amTIVJcqauFGjSDnCFA/mpYnabJgoQv6119fE2fcLPHSavCetLingCL+zrMqk57IvfYRw==",
+      "version": "1.0.0-beta.55",
+      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.0.0-beta.55.tgz",
+      "integrity": "sha512-VfzvwpSDHXqRVelIxsBVhgbV9BkFvhJ/q+bKhnVUUXV0JAhMK/7uC92TsqKk4EBYuqpHyZ1jjqrL4n03fMU7zw==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "crypto-browserify": "3.12.0",
+        "browserify-cipher": "^1.0.1",
         "eth-lib": "0.2.8",
         "lodash": "^4.17.11",
-        "scrypt.js": "0.2.0",
+        "pbkdf2": "^3.0.17",
+        "randombytes": "^2.1.0",
+        "scrypt.js": "0.3.0",
         "uuid": "3.3.2",
-        "web3-core": "1.0.0-beta.46",
-        "web3-core-helpers": "1.0.0-beta.46",
-        "web3-core-method": "1.0.0-beta.46",
-        "web3-providers": "1.0.0-beta.46",
-        "web3-utils": "1.0.0-beta.46"
-      },
-      "dependencies": {
-        "eth-lib": {
-          "version": "0.2.8",
-          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
-          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
-          "dev": true,
-          "requires": {
-            "bn.js": "^4.11.6",
-            "elliptic": "^6.4.0",
-            "xhr-request-promise": "^0.1.2"
-          }
-        }
+        "web3-core": "1.0.0-beta.55",
+        "web3-core-helpers": "1.0.0-beta.55",
+        "web3-core-method": "1.0.0-beta.55",
+        "web3-providers": "1.0.0-beta.55",
+        "web3-utils": "1.0.0-beta.55"
       }
     },
     "web3-eth-contract": {
-      "version": "1.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.0.0-beta.46.tgz",
-      "integrity": "sha512-hcr5a9/SC8CwpV7ZNXuLQXEpzDcJudS1OlPYMQjnrFVjkjRtuYNb6ldUTaTK9R2WV5bVws9qQEJbvsD+NPnqHw==",
+      "version": "1.0.0-beta.55",
+      "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.0.0-beta.55.tgz",
+      "integrity": "sha512-v6oB1wfH039/A5sTb4ZTKX++fcBTHEkuQGpq50ATIDoxP/UTz2+6S+iL+3sCJTsByPw2/Bni/HM7NmLkXqzg/Q==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.3.1",
+        "@types/bn.js": "^4.11.4",
         "lodash": "^4.17.11",
-        "web3-core": "1.0.0-beta.46",
-        "web3-core-helpers": "1.0.0-beta.46",
-        "web3-core-method": "1.0.0-beta.46",
-        "web3-core-promievent": "1.0.0-beta.46",
-        "web3-core-subscriptions": "1.0.0-beta.46",
-        "web3-eth-abi": "1.0.0-beta.46",
-        "web3-eth-accounts": "1.0.0-beta.46",
-        "web3-providers": "1.0.0-beta.46",
-        "web3-utils": "1.0.0-beta.46"
+        "web3-core": "1.0.0-beta.55",
+        "web3-core-helpers": "1.0.0-beta.55",
+        "web3-core-method": "1.0.0-beta.55",
+        "web3-core-subscriptions": "1.0.0-beta.55",
+        "web3-eth-abi": "1.0.0-beta.55",
+        "web3-eth-accounts": "1.0.0-beta.55",
+        "web3-providers": "1.0.0-beta.55",
+        "web3-utils": "1.0.0-beta.55"
       }
     },
     "web3-eth-ens": {
-      "version": "1.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.0.0-beta.46.tgz",
-      "integrity": "sha512-7wXZnFW66ZQUD0gMUTdYsnz5VG9yo/PzJmccL73Swza6NHMpeejTNMgUc/GUzyE3449+Mu/37o3hRu3Z4eWi/w==",
+      "version": "1.0.0-beta.55",
+      "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.0.0-beta.55.tgz",
+      "integrity": "sha512-jEL17coO0FJXb7KYq4+7DhVXj0Rh+wHfZ86jOvFUvJsRaUHfqK2TlMatuhD2mbrmxpBYb6oMPnXVnNK9bnD5Rg==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.3.1",
         "eth-ens-namehash": "2.0.8",
         "lodash": "^4.17.11",
-        "web3-core": "1.0.0-beta.46",
-        "web3-core-helpers": "1.0.0-beta.46",
-        "web3-core-method": "1.0.0-beta.46",
-        "web3-core-promievent": "1.0.0-beta.46",
-        "web3-eth-abi": "1.0.0-beta.46",
-        "web3-eth-contract": "1.0.0-beta.46",
-        "web3-net": "1.0.0-beta.46",
-        "web3-providers": "1.0.0-beta.46",
-        "web3-utils": "1.0.0-beta.46"
+        "web3-core": "1.0.0-beta.55",
+        "web3-core-helpers": "1.0.0-beta.55",
+        "web3-core-method": "1.0.0-beta.55",
+        "web3-eth-abi": "1.0.0-beta.55",
+        "web3-eth-accounts": "1.0.0-beta.55",
+        "web3-eth-contract": "1.0.0-beta.55",
+        "web3-net": "1.0.0-beta.55",
+        "web3-providers": "1.0.0-beta.55",
+        "web3-utils": "1.0.0-beta.55"
       }
     },
     "web3-eth-iban": {
-      "version": "1.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.46.tgz",
-      "integrity": "sha512-IM9VbznRaEs58n7mYbJcPviOLMAiiveqZT1jtlcJ/DbrvMkArV0Xf6n2OyFY+ak3ppddKVMIAGISxhky6r/7cg==",
+      "version": "1.0.0-beta.55",
+      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.55.tgz",
+      "integrity": "sha512-a2Fxsb5Mssa+jiXgjUdIzJipE0175IcQXJbZLpKft2+zeSJWNTbaa3PQD2vPPpIM4W789q06N+f9Zc0Fyls+1g==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.3.1",
         "bn.js": "4.11.8",
-        "web3-utils": "1.0.0-beta.46"
+        "web3-utils": "1.0.0-beta.55"
       }
     },
     "web3-eth-personal": {
-      "version": "1.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.0.0-beta.46.tgz",
-      "integrity": "sha512-NEmuitdSmoeixXfnw23Br8YZGmAw2iH79gUEvYPto0OQ7edc1LtkZP6h0lFPwXRPhz0Z8UDOg+lv31EN4NKBwA==",
+      "version": "1.0.0-beta.55",
+      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.0.0-beta.55.tgz",
+      "integrity": "sha512-H0mahLQx6Oj7lpgTamKAswr3rHChRUZijeWAar2Hj7BABQlLRKwx8n09nYhxggvvLYQNQS90JjvQue7rAo2LQQ==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "web3-core": "1.0.0-beta.46",
-        "web3-core-helpers": "1.0.0-beta.46",
-        "web3-core-method": "1.0.0-beta.46",
-        "web3-net": "1.0.0-beta.46",
-        "web3-providers": "1.0.0-beta.46",
-        "web3-utils": "1.0.0-beta.46"
+        "web3-core": "1.0.0-beta.55",
+        "web3-core-helpers": "1.0.0-beta.55",
+        "web3-core-method": "1.0.0-beta.55",
+        "web3-eth-accounts": "1.0.0-beta.55",
+        "web3-net": "1.0.0-beta.55",
+        "web3-providers": "1.0.0-beta.55",
+        "web3-utils": "1.0.0-beta.55"
       }
     },
     "web3-net": {
-      "version": "1.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.0.0-beta.46.tgz",
-      "integrity": "sha512-mSEgq5S1SI/M17pS6UEGYBt6v54gaSYw3hvRmx5pu4zoHMz8YmbUSfZh+98uxtcV/TE9v3rCwZur7/0bar9kCA==",
+      "version": "1.0.0-beta.55",
+      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.0.0-beta.55.tgz",
+      "integrity": "sha512-do2WY8+/GArJSWX7k/zZ7nBnV9Y3n6LhPYkwT3LeFqDzD515bKwlomaNC8hOaTc6UQyXIoPprYTK2FevL7jrZw==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.3.1",
         "lodash": "^4.17.11",
-        "web3-core": "1.0.0-beta.46",
-        "web3-core-helpers": "1.0.0-beta.46",
-        "web3-core-method": "1.0.0-beta.46",
-        "web3-providers": "1.0.0-beta.46",
-        "web3-utils": "1.0.0-beta.46"
+        "web3-core": "1.0.0-beta.55",
+        "web3-core-helpers": "1.0.0-beta.55",
+        "web3-core-method": "1.0.0-beta.55",
+        "web3-providers": "1.0.0-beta.55",
+        "web3-utils": "1.0.0-beta.55"
       }
     },
     "web3-providers": {
-      "version": "1.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/web3-providers/-/web3-providers-1.0.0-beta.46.tgz",
-      "integrity": "sha512-5h4dFuASthr+EE8xBpAtQ5b5bngjv1ihIBcyEVQEP+bRtvU7qPKA8It2fQLtDl4iSADJDjhhQmvBPKbSlJ9jWg==",
+      "version": "1.0.0-beta.55",
+      "resolved": "https://registry.npmjs.org/web3-providers/-/web3-providers-1.0.0-beta.55.tgz",
+      "integrity": "sha512-MNifc7W+iF6rykpbDR1MuX152jshWdZXHAU9Dk0Ja2/23elhIs4nCWs7wOX9FHrKgdrQbscPoq0uy+0aGzyWVQ==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.3.1",
         "@types/node": "^10.12.18",
         "eventemitter3": "3.1.0",
         "lodash": "^4.17.11",
-        "oboe": "2.1.4",
         "url-parse": "1.4.4",
-        "websocket": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
+        "web3-core": "1.0.0-beta.55",
+        "web3-core-helpers": "1.0.0-beta.55",
+        "web3-core-method": "1.0.0-beta.55",
+        "web3-utils": "1.0.0-beta.55",
+        "websocket": "^1.0.28",
         "xhr2-cookies": "1.1.0"
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.14.6",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.6.tgz",
-          "integrity": "sha512-Fvm24+u85lGmV4hT5G++aht2C5I4Z4dYlWZIh62FAfFO/TfzXtPpoLI6I7AuBWkIFqZCnhFOoTT7RjjaIL5Fjg==",
+          "version": "10.14.8",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.8.tgz",
+          "integrity": "sha512-I4+DbJEhLEg4/vIy/2gkWDvXBOOtPKV9EnLhYjMoqxcRW+TTZtUftkHktz/a8suoD5mUL7m6ReLrkPvSsCQQmw==",
           "dev": true
         }
       }
     },
     "web3-shh": {
-      "version": "1.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.0.0-beta.46.tgz",
-      "integrity": "sha512-1Qka0DEXbcC07+HAdXM9i848FseaGi/G719aU0XbuEZgjbLYp8/uuKExrRkq9kLly6CIPwq20lrVRzScblAKQw==",
+      "version": "1.0.0-beta.55",
+      "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.0.0-beta.55.tgz",
+      "integrity": "sha512-lGP2HQ/1ThNnfoU8677aL48KsTx4Ht+2KQIn39dGpxVZqysQmovQIltbymVnAr4h8wofwcEz46iNHGa+PAyNzA==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "web3-core": "1.0.0-beta.46",
-        "web3-core-helpers": "1.0.0-beta.46",
-        "web3-core-method": "1.0.0-beta.46",
-        "web3-core-subscriptions": "1.0.0-beta.46",
-        "web3-net": "1.0.0-beta.46",
-        "web3-providers": "1.0.0-beta.46",
-        "web3-utils": "1.0.0-beta.46"
+        "web3-core": "1.0.0-beta.55",
+        "web3-core-helpers": "1.0.0-beta.55",
+        "web3-core-method": "1.0.0-beta.55",
+        "web3-core-subscriptions": "1.0.0-beta.55",
+        "web3-net": "1.0.0-beta.55",
+        "web3-providers": "1.0.0-beta.55",
+        "web3-utils": "1.0.0-beta.55"
       }
     },
     "web3-utils": {
-      "version": "1.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.46.tgz",
-      "integrity": "sha512-mSz+NrAil2fDZkxTXHPntCclZ8DofMjv8Q+BYR0VAyzTzylpYNXAV0WDdxBp/sXgniWRZXZMF7OkQNWqhZ1J9g==",
+      "version": "1.0.0-beta.55",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.55.tgz",
+      "integrity": "sha512-ASWqUi8gtWK02Tp8ZtcoAbHenMpQXNvHrakgzvqTNNZn26wgpv+Q4mdPi0KOR6ZgHFL8R/9b5BBoUTglS1WPpg==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.3.1",
@@ -16845,26 +16656,15 @@
         "ethjs-unit": "^0.1.6",
         "lodash": "^4.17.11",
         "number-to-bn": "1.7.0",
-        "randomhex": "0.1.5",
+        "randombytes": "^2.1.0",
         "utf8": "2.1.1"
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.14.6",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.6.tgz",
-          "integrity": "sha512-Fvm24+u85lGmV4hT5G++aht2C5I4Z4dYlWZIh62FAfFO/TfzXtPpoLI6I7AuBWkIFqZCnhFOoTT7RjjaIL5Fjg==",
+          "version": "10.14.8",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.8.tgz",
+          "integrity": "sha512-I4+DbJEhLEg4/vIy/2gkWDvXBOOtPKV9EnLhYjMoqxcRW+TTZtUftkHktz/a8suoD5mUL7m6ReLrkPvSsCQQmw==",
           "dev": true
-        },
-        "eth-lib": {
-          "version": "0.2.8",
-          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
-          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
-          "dev": true,
-          "requires": {
-            "bn.js": "^4.11.6",
-            "elliptic": "^6.4.0",
-            "xhr-request-promise": "^0.1.2"
-          }
         }
       }
     },
@@ -17350,13 +17150,14 @@
       }
     },
     "websocket": {
-      "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
-      "from": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
+      "version": "1.0.28",
+      "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.28.tgz",
+      "integrity": "sha512-00y/20/80P7H4bCYkzuuvvfDvh+dgtXi5kzDf3UcZwN6boTYaKvsrtZ5lIYm1Gsg48siMErd9M4zjSYfYFHTrA==",
       "dev": true,
       "requires": {
         "debug": "^2.2.0",
-        "nan": "^2.3.3",
-        "typedarray-to-buffer": "^3.1.2",
+        "nan": "^2.11.0",
+        "typedarray-to-buffer": "^3.1.5",
         "yaeti": "^0.0.6"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "solidity-ide",
-  "version": "2.2.4",
+  "version": "2.3.0",
   "private": false,
   "description": "A light and easy IDE for Solidity smart contract development.",
   "author": "SystemGlitch",
@@ -56,7 +56,7 @@
     "split.js": "^1.5.10",
     "vue": "^2.6.10",
     "vue-template-compiler": "^2.6.10",
-    "web3": "1.0.0-beta.46",
+    "web3": "^1.0.0-beta.55",
     "webpack": "^4.29.6"
   },
   "eslintConfig": {

--- a/solc-server.js
+++ b/solc-server.js
@@ -275,7 +275,7 @@ function listDir(dir) {
             if((stats.isFile() && !item.endsWith('.sol')) || (!stats.isFile() && !stats.isDirectory())) {
                 continue // Skip non-sol files and non-directories
             }
-            const file = {name: item, path: dir + item, directory: stats.isDirectory(), state: 0, saved: true}
+            const file = {name: item, path: (dir + item).replace(/\\/g, '/'), directory: stats.isDirectory(), state: 0, saved: true}
             result.push(file)
             if(stats.isDirectory()) {
                 file.childs = []

--- a/solc-server.js
+++ b/solc-server.js
@@ -21,6 +21,8 @@ const express = require('express')
 const bodyParser = require('body-parser')
 const app = express()
 
+const ignored = ['build', 'node_modules']
+
 console.log("Starting solc server...")
 
 if(!directory.endsWith(FILE_SEPARATOR))
@@ -304,12 +306,21 @@ function listDirForCompile(dir, result) {
             }
         }
 
-        if(stats.isDirectory() && !item.endsWith('build')) {
+        if(stats.isDirectory() && checkNotIgnored(item)) {
             listDirForCompile(dir + item + '/', result)
         }
     }
 
     return result
+}
+
+function checkNotIgnored(dir) {
+    for(let key in ignored) {
+        if(dir.endsWith(ignored)) {
+            return false
+        }
+    }
+    return true
 }
 
 function validateFile(path, res) {

--- a/src/components/Browser.vue
+++ b/src/components/Browser.vue
@@ -211,7 +211,7 @@
             refreshFileState: function() {
                 for(let key in this.messages) {
                     const message = this.messages[key];
-                    const file = this.findFile(this.files, message.sourceLocation.file);
+                    const file = this.findFile(this.files, message.sourceLocation.file.replace(/\\/g, '/'));
                     if(file != null) {
                         const newState = this.getStateFromSeverity(message.severity);
                         file.state = file.state < newState ? newState : file.state;

--- a/src/components/Browser.vue
+++ b/src/components/Browser.vue
@@ -220,8 +220,8 @@
             },
             loadDirectory: function(path, directory, directoryComponent, index) {
                 const pathArr = path.split('/');
-                const dirPath = pathArr.splice(0, index++).join('/');
-                const dir = this.findDirectory(dirPath + '/', directory, 0, false);
+                const dirPath = pathArr.splice(0, index).join('/');
+                const dir = this.findDirectory(dirPath + '/', directory, index - 1, false);
                 if(dir) {
                     const subdirCmp = directoryComponent.$refs['directory_' + dir.path];
                     if(subdirCmp[0]) {
@@ -230,7 +230,7 @@
                                 this.select(this.findFile(this.files, localStorage['openFile']));
                             } else {
                                 setTimeout(() => {
-                                    this.loadDirectory(path, subdir, subdirCmp[0], index);
+                                    this.loadDirectory(path, subdir, subdirCmp[0], index + 1);
                                 }, 0);
                             }
                         });
@@ -295,7 +295,6 @@
                 const length = pathArr.length;
                 const name = pathArr[index++];
                 const dirPath = pathArr.splice(0, index).join('/');
-
 
                 for(let key in directory.childs) {
                     const dir = directory.childs[key];

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -86,13 +86,13 @@
             },
             deploy: function(contractName, compiledContract, params) {
                 this.checkAbi(compiledContract.abi);
-                const contract = new window.web3.eth.Contract(compiledContract.abi);
+                const contract = new window.web3.eth.Contract(compiledContract.abi, undefined, {transactionConfirmationBlocks: 1});
                 const activeAccount = window.accountManager.getActiveAccount();
                 GlobalEvent.$emit('processing', true);
 
                 contract.deploy({
                     data: compiledContract.evm.bytecode.object,
-                    arguments: params,
+                    arguments: params
                 }).send({
                     from: activeAccount.address,
                     gas: '4700000',


### PR DESCRIPTION
# Merge branchBuildSave (ABI and bytecode save to filesystem)

## Description

* On compile, save the ABI and contracts bytecode to a new `build` folder.
* Ignore the `build` folder and `node_modules` folder when compiling.
* Fixed several path bugs on windows (such as file missing state).
* Fixed a bug that prevented nested folders to open automatically on refresh.
* Update to latest web3 version.

### Benefits

Deploying the contract in production or on a testnet would be easier and wouldn't require the use of another tool.

### Possible drawbacks

`None`.

## Related issue(s)

* #17 (Save ABI and compiled contract)
